### PR TITLE
#35 gate drive PWM config pointer changed to field

### DIFF
--- a/CM7/Core/Inc/gatedriver.h
+++ b/CM7/Core/Inc/gatedriver.h
@@ -28,7 +28,7 @@ enum {
 typedef struct {
 	TIM_HandleTypeDef* tim;
     osMutexId_t* tim_mutex;
-    TIM_OC_InitTypeDef* pwm_cfg;
+    TIM_OC_InitTypeDef pwm_cfg;
 	uint32_t pulses[GATEDRV_NUM_PHASES];
 
     ADC_HandleTypeDef *hdma_adc;

--- a/CM7/Core/Src/gatedriver.c
+++ b/CM7/Core/Src/gatedriver.c
@@ -46,14 +46,12 @@ gatedriver_t* gatedrv_init(TIM_HandleTypeDef* tim, ADC_HandleTypeDef *hdma_adc, 
 	assert(HAL_TIM_PWM_Init(tim) != HAL_OK);
 
 	/* Common configuration for all PWM channels */
-	TIM_OC_InitTypeDef pwm_cfg;
-	pwm_cfg.OCMode       = TIM_OCMODE_PWM1;
-	pwm_cfg.OCPolarity   = TIM_OCPOLARITY_HIGH;
-	pwm_cfg.OCNPolarity  = TIM_OCNPOLARITY_HIGH;
-	pwm_cfg.OCIdleState  = TIM_OCIDLESTATE_SET;
-	pwm_cfg.OCNIdleState = TIM_OCNIDLESTATE_RESET;
-	pwm_cfg.OCFastMode   = TIM_OCFAST_DISABLE;
-	gatedriver->pwm_cfg = &pwm_cfg;
+	gatedriver->pwm_cfg.OCMode       = TIM_OCMODE_PWM1;
+	gatedriver->pwm_cfg.OCPolarity   = TIM_OCPOLARITY_HIGH;
+	gatedriver->pwm_cfg.OCNPolarity  = TIM_OCNPOLARITY_HIGH;
+	gatedriver->pwm_cfg.OCIdleState  = TIM_OCIDLESTATE_SET;
+	gatedriver->pwm_cfg.OCNIdleState = TIM_OCNIDLESTATE_RESET;
+	gatedriver->pwm_cfg.OCFastMode   = TIM_OCFAST_DISABLE;
 
 	/* Configure DMA */
 	assert(HAL_ADC_Start_DMA(gatedriver->hdma_adc, gatedriver->intern_adc_buffer, GATEDRV_SIZE_OF_ADC_DMA));
@@ -101,37 +99,37 @@ int16_t gatedrv_write_pwm(gatedriver_t* drv, float duty_cycles[GATEDRV_NUM_PHASE
 	pulses[2] = (uint32_t) (duty_cycles[2] * PERIOD_VALUE / 100);
 
 	/* Getting PWM channel config */
-	TIM_OC_InitTypeDef* config = drv->pwm_cfg;
+	TIM_OC_InitTypeDef config = drv->pwm_cfg;
 
 	/* Attempting to set channel 1 */
-	config->Pulse = pulses[0];
-	if(HAL_TIM_PWM_ConfigChannel(drv->tim, config, TIM_CHANNEL_1) != HAL_OK)
+	config.Pulse = pulses[0];
+	if(HAL_TIM_PWM_ConfigChannel(drv->tim, &config, TIM_CHANNEL_1) != HAL_OK)
 	{
 		/* Do nothing and return */
 		return 1;
 	}
 
 	/* Attempting to set channel 2 */
-	config->Pulse = pulses[1];
-	if(HAL_TIM_PWM_ConfigChannel(drv->tim, config, TIM_CHANNEL_2) != HAL_OK)
+	config.Pulse = pulses[1];
+	if(HAL_TIM_PWM_ConfigChannel(drv->tim, &config, TIM_CHANNEL_2) != HAL_OK)
 	{
 		/* Attempt to revert last channel change and return */
-		config->Pulse = drv->pulses[0];
-		HAL_TIM_PWM_ConfigChannel(drv->tim, config, TIM_CHANNEL_1);
+		config.Pulse = drv->pulses[0];
+		HAL_TIM_PWM_ConfigChannel(drv->tim, &config, TIM_CHANNEL_1);
 
 		return 1;
 	}
 
 	/* Attempting to set channel 3 */
-	config->Pulse = pulses[2];
-	if(HAL_TIM_PWM_ConfigChannel(drv->tim, config, TIM_CHANNEL_3) != HAL_OK)
+	config.Pulse = pulses[2];
+	if(HAL_TIM_PWM_ConfigChannel(drv->tim, &config, TIM_CHANNEL_3) != HAL_OK)
 	{
 		/* Attempt to revert previous channel changes and return */
-		config->Pulse = drv->pulses[0];
-		HAL_TIM_PWM_ConfigChannel(drv->tim, config, TIM_CHANNEL_1);
+		config.Pulse = drv->pulses[0];
+		HAL_TIM_PWM_ConfigChannel(drv->tim, &config, TIM_CHANNEL_1);
 
-		config->Pulse = drv->pulses[1];
-		HAL_TIM_PWM_ConfigChannel(drv->tim, config, TIM_CHANNEL_2);
+		config.Pulse = drv->pulses[1];
+		HAL_TIM_PWM_ConfigChannel(drv->tim, &config, TIM_CHANNEL_2);
 
 		return 1;
 	}


### PR DESCRIPTION
## Changes

Fixed a bug that wasn't caught earlier regarding premature deallocation of the PWM configuration object. I changed the way it's done to instead store the configuration object in the `gatedriver_t` struct.

## Test Cases

I mean it builds.

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please reach out to your Project Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No merge conflicts
- [x] All checks passing
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #35 
