### PR TITLE
Verified AMP configuration of FreeRTOS with LED blinking

### DIFF
--- a/CM4/Core/Src/main.c
+++ b/CM4/Core/Src/main.c
@@ -152,7 +152,7 @@ int main(void)
   //MX_USB_OTG_FS_PCD_Init();
   MX_UART4_Init();
   /* USER CODE BEGIN 2 */
-  printf("Testing");
+
   /* USER CODE END 2 */
 
   /* Init scheduler */
@@ -423,6 +423,7 @@ static void MX_DMA_Init(void)
 static void MX_GPIO_Init(void)
 {
 /* USER CODE BEGIN MX_GPIO_Init_1 */
+  GPIO_InitTypeDef GPIO_InitStruct = {0};
 /* USER CODE END MX_GPIO_Init_1 */
 
   /* GPIO Ports Clock Enable */
@@ -435,6 +436,30 @@ static void MX_GPIO_Init(void)
   __HAL_RCC_GPIOB_CLK_ENABLE();
 
 /* USER CODE BEGIN MX_GPIO_Init_2 */
+  GPIO_InitStruct.Pin = GPIO_PIN_14;
+  GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
+  GPIO_InitStruct.Pull = GPIO_NOPULL;
+  GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+  HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
+
+  GPIO_InitStruct.Pin = GPIO_PIN_15;
+  GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
+  GPIO_InitStruct.Pull = GPIO_NOPULL;
+  GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+  HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
+
+  /* Configure UART TX Pin */
+  GPIO_InitStruct.Pin = GPIO_PIN_0;
+  GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
+  GPIO_InitStruct.Pull = GPIO_NOPULL;
+  GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_HIGH;
+  GPIO_InitStruct.Alternate = GPIO_AF8_UART4;
+  HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
+
+  /* Configure UART RX Pin */
+  GPIO_InitStruct.Pin = GPIO_PIN_1;
+  GPIO_InitStruct.Alternate = GPIO_AF8_UART4;
+  HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
 /* USER CODE END MX_GPIO_Init_2 */
 }
 
@@ -452,10 +477,17 @@ static void MX_GPIO_Init(void)
 void StartDefaultTask(void *argument)
 {
   /* USER CODE BEGIN 5 */
+  uint8_t i = 0;
   /* Infinite loop */
   for (;;)
   {
-    osDelay(1);
+    HAL_GPIO_TogglePin(GPIOC, GPIO_PIN_15);
+    if (i % 2 != 0)
+      printf(".\r\n");
+    else
+      printf("..\r\n");
+    osDelay(1000);
+    i++;
   }
   /* USER CODE END 5 */
 }

--- a/CM7/Core/Src/main.c
+++ b/CM7/Core/Src/main.c
@@ -126,10 +126,12 @@ int main(void)
     ;
   if (timeout < 0)
   {
-    Error_Handler();
+    //Error_Handler();
   }
 /* USER CODE END Boot_Mode_Sequence_1 */
   /* MCU Configuration--------------------------------------------------------*/
+
+  HAL_GPIO_WritePin(GPIOC, GPIO_PIN_All, 0);
 
   /* Reset of all peripherals, Initializes the Flash interface and the Systick. */
   HAL_Init();
@@ -158,7 +160,7 @@ int main(void)
     ;
   if (timeout < 0)
   {
-    Error_Handler();
+    //Error_Handler();
   }
 /* USER CODE END Boot_Mode_Sequence_2 */
 
@@ -181,31 +183,6 @@ int main(void)
   MX_TIM8_Init();
   MX_CRC_Init();
   /* USER CODE BEGIN 2 */
-
-  HAL_GPIO_TogglePin(GPIOC, GPIO_PIN_13);
-  HAL_GPIO_TogglePin(GPIOC, GPIO_PIN_14);
-  HAL_GPIO_TogglePin(GPIOC, GPIO_PIN_15);
-  HAL_Delay(100);
-  HAL_GPIO_TogglePin(GPIOC, GPIO_PIN_13);
-  HAL_GPIO_TogglePin(GPIOC, GPIO_PIN_14);
-  HAL_GPIO_TogglePin(GPIOC, GPIO_PIN_15);
-  HAL_Delay(100);
-  HAL_GPIO_TogglePin(GPIOC, GPIO_PIN_13);
-  HAL_GPIO_TogglePin(GPIOC, GPIO_PIN_14);
-  HAL_GPIO_TogglePin(GPIOC, GPIO_PIN_15);
-  HAL_Delay(100);
-  HAL_GPIO_TogglePin(GPIOC, GPIO_PIN_13);
-  HAL_GPIO_TogglePin(GPIOC, GPIO_PIN_14);
-  HAL_GPIO_TogglePin(GPIOC, GPIO_PIN_15);
-  HAL_Delay(100);
-  HAL_GPIO_TogglePin(GPIOC, GPIO_PIN_13);
-  HAL_GPIO_TogglePin(GPIOC, GPIO_PIN_14);
-  HAL_GPIO_TogglePin(GPIOC, GPIO_PIN_15);
-  HAL_Delay(100);
-  HAL_GPIO_TogglePin(GPIOC, GPIO_PIN_13);
-
-  HAL_Delay(100);
-
 
   /* USER CODE END 2 */
 
@@ -1129,6 +1106,7 @@ static void MX_DMA_Init(void)
 static void MX_GPIO_Init(void)
 {
 /* USER CODE BEGIN MX_GPIO_Init_1 */
+  GPIO_InitTypeDef GPIO_InitStruct = {0};
 /* USER CODE END MX_GPIO_Init_1 */
 
   /* GPIO Ports Clock Enable */
@@ -1142,6 +1120,12 @@ static void MX_GPIO_Init(void)
   __HAL_RCC_GPIOG_CLK_ENABLE();
 
 /* USER CODE BEGIN MX_GPIO_Init_2 */
+
+GPIO_InitStruct.Pin = GPIO_PIN_13;
+GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
+GPIO_InitStruct.Pull = GPIO_NOPULL;
+GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
 /* USER CODE END MX_GPIO_Init_2 */
 }
 
@@ -1162,7 +1146,8 @@ void StartDefaultTask(void *argument)
   /* Infinite loop */
   for (;;)
   {
-    osDelay(1);
+    HAL_GPIO_TogglePin(GPIOC, GPIO_PIN_13);
+    osDelay(500);
   }
   /* USER CODE END 5 */
 }

--- a/README.md
+++ b/README.md
@@ -11,5 +11,8 @@ docker compose pull
 
 # Run Container
 docker compose run --rm ner-gcc-arm
+
+# (Temporary) to flash in Docker container
+openocd -f ./flash_mcu.cfg
 ```
 

--- a/flash_mcu.cfg
+++ b/flash_mcu.cfg
@@ -1,15 +1,35 @@
+source [find ft2232h_jtag.cfg]
+source [find stm32h745.cfg]
+
+# Adapter speed
 adapter speed 5000
+
+# Initialize and configure the target
 init
+
+# Configure FreeRTOS awareness for both cores
+targets stm32h7x.cpu0
+stm32h7x.cpu0 configure -rtos FreeRTOS
+
+targets stm32h7x.cpu1
+stm32h7x.cpu1 configure -rtos FreeRTOS
+
+# Flash and verify the programs for both cores
 targets stm32h7x.cpu0
 program ./Makefile/CM7/build/proteus_CM7.elf verify
 reset
 halt
+
 targets stm32h7x.cpu1
 program ./Makefile/CM4/build/proteus_CM4.elf verify
 reset
 halt
+
+# Start both cores
 targets stm32h7x.cpu0
 reset run
+
 targets stm32h7x.cpu1
 reset run
+
 exit

--- a/ft2232h_jtag.cfg
+++ b/ft2232h_jtag.cfg
@@ -5,6 +5,9 @@ ftdi_vid_pid 0x0403 0x6010
 # and 0x000b sets the required initial states for your other signals.
 ftdi_layout_init 0x0008 0x000b
 
+ftdi_layout_signal LED_Tx -data 0x00F0 -oe 0x00F0
+ftdi_layout_signal LED_Rx -data 0x00F0 -oe 0x00F0
+
 # Configure GPIOL0 (ADBUS4) as nSRST, assuming active low reset
 # Setting `-data` for active low, `-oe` to enable output.
 # If tri-state isn't supported, this configures the pin as push-pull.


### PR DESCRIPTION
## Changes

Took a bit to get this going. Basically I was able to verify that we can flash AND run two RTOS instances side by in the STM32H745. Got to the point where we can blink LEDs at a fix rate via an RTOS delay. UART also verified in this

## Notes

Revamped OpenOCD flash procedure. I learned a shit ton about OpenOCD and found out you can print raw register contents fairly easily with OpenOCD and used it to verify that I was writing to the correct GPIO reg without GDB. 

Also general note that GDB is gonna take some finesse to get working. I tried to create a tmux script that would start two GDB sessions and I got both of them working and pointed to different cores at the same time but if you start either it throws a large error. Here is my little script that worked for future reference, you just need to remove `exit` from the end of the OpenOCD flash script to keep it running forever:
```
#!/bin/bash

SESSION_NAME="debug_session"

# Start OpenOCD in the background
openocd -f flash_mcu.cfg &

# Give OpenOCD some time to start up
sleep 10

# Create a new tmux session in the background
tmux new-session -d -s $SESSION_NAME

# In the top pane, start GDB for Cortex-M7 (Core 0)
tmux send-keys -t $SESSION_NAME:0.0 "arm-none-eabi-gdb ./Makefile/CM7/build/proteus_CM7.elf -ex 'target remote localhost:3333'" C-m
tmux send-keys -t $SESSION_NAME:0.0 "monitor reset halt" C-m
tmux send-keys -t $SESSION_NAME:0.0 "load" C-m
tmux send-keys -t $SESSION_NAME:0.0 "monitor reset init" C-m

sleep 5

# Split the window vertically and create two panes
tmux split-window -v

# In the bottom pane, start GDB for Cortex-M4 (Core 1)
tmux send-keys -t $SESSION_NAME:0.1 "arm-none-eabi-gdb ./Makefile/CM4/build/proteus_CM4.elf -ex 'target remote localhost:3334'" C-m
tmux send-keys -t $SESSION_NAME:0.1 "target remote localhost:3334" C-m
tmux send-keys -t $SESSION_NAME:0.1 "monitor reset halt" C-m
tmux send-keys -t $SESSION_NAME:0.1 "load" C-m
tmux send-keys -t $SESSION_NAME:0.1 "monitor reset init" C-m

# Attach to the tmux session
tmux attach-session -t $SESSION_NAME

kill $(pidof openocd)
``` 

## Test Cases

- Built
- Verified on a register level
- Verified on a blinky LED level
- Verified UART 

## To Do

_Any remaining things that need to get done_

- nah
