### PR TITLE
Revamping state machine implementation

### DIFF
--- a/CM7/Core/Inc/foc_ctrl.h
+++ b/CM7/Core/Inc/foc_ctrl.h
@@ -8,6 +8,7 @@
 #include "ipark.h"
 #include "svgen.h"
 #include "pid.h"
+#include "state_machine.h"
 
 typedef enum {
     SECTOR_1 = 0,
@@ -61,9 +62,11 @@ typedef struct {
 	PARK_Obj park_transform;
 	IPARK_Obj ipark_transform;
 	SVGEN_Obj svm;
+
+	state_machine_t *sm;
 } foc_ctrl_t;
 
-void foc_ctrl_init(foc_ctrl_t *controller);
+void foc_ctrl_init(foc_ctrl_t *controller, state_machine_t *sm);
 
 /* Enqueue a single frame of controller observation */
 osStatus_t foc_queue_frame(foc_ctrl_t *controller, foc_data_t *phase_currents);

--- a/CM7/Core/Inc/state_machine.h
+++ b/CM7/Core/Inc/state_machine.h
@@ -8,17 +8,21 @@ typedef struct {
     state_t current_state;
     osMutexId_t* state_mutex;
     osMutexAttr_t state_mutex_attr;
-} state_director_t;
+    osMessageQueueId_t state_trans_queue;
+    osThreadId_t thread;
+} state_machine_t;
 
-extern osThreadId_t sm_director_handle;
 extern const osThreadAttr_t sm_director_attributes;
 
-void vStateMachineDirector(void *pv_params);
+/* Initialize a State Machine */
+void state_machine_init(state_machine_t *sm);
 
 /* Adds a functional state transition to be processed */
-int queue_state(state_t new_state);
+int state_machine_queue_state(state_machine_t *sm, state_t new_state);
 
 /* Retrieves the current functional state */
-state_t get_state();
+state_t state_machine_get_state(state_machine_t *sm);
+
+void vStateMachineDirector(void *pv_params);
 
 #endif

--- a/CM7/Core/Src/state_machine.c
+++ b/CM7/Core/Src/state_machine.c
@@ -5,9 +5,6 @@
 
 #define STATE_TRANS_QUEUE_SIZE 16
 
-/* Internal State of Vehicle */
-state_director_t proteus_state;
-
 /* State Transition Map */
 // TODO: fill out state transition map
 static const bool valid_trans_to_from[MAX_FUNC_STATES][MAX_FUNC_STATES] = {
@@ -24,64 +21,68 @@ static const bool valid_trans_to_from[MAX_FUNC_STATES][MAX_FUNC_STATES] = {
     {true, true, false, false, false, false, false, false, true, true},    /* FAULTED */
 };
 
-osThreadId_t sm_director_handle;
+void state_machine_init(state_machine_t *sm)
+{
+    sm->current_state = LV_BOOT;
+
+    sm->state_mutex = osMutexNew(&sm->state_mutex_attr);
+	assert(sm->state_mutex);
+
+    sm->state_trans_queue = osMessageQueueNew(STATE_TRANS_QUEUE_SIZE, sizeof(state_t), NULL);
+}
+
+int state_machine_queue_state(state_machine_t *sm, state_t new_state)
+{
+    if (!sm->state_trans_queue)
+        return 1;
+
+    return osMessageQueuePut(sm->state_trans_queue, &new_state, 0U, 0U);
+}
+
+state_t state_machine_get_state(state_machine_t *sm)
+{
+    state_t ret;
+    osStatus_t mut_stat = osMutexAcquire(sm->state_mutex, osWaitForever);
+	if (mut_stat) {
+		return -1;
+	}
+
+    ret = sm->current_state;
+
+    osMutexRelease(sm->state_mutex);
+
+    return ret;
+}
+
 const osThreadAttr_t sm_director_attributes = {
     .name = "State Machine Director",
     .stack_size = 128 * 4,
     .priority = (osPriority_t)osPriorityAboveNormal3,
 };
 
-static osMessageQueueId_t state_trans_queue;
-
-int queue_state(state_t new_state)
-{
-    if (!state_trans_queue)
-        return 1;
-
-    return osMessageQueuePut(state_trans_queue, &new_state, 0U, 0U);
-}
-
-state_t get_state()
-{
-    state_t ret;
-    osStatus_t mut_stat = osMutexAcquire(proteus_state.state_mutex, osWaitForever);
-	if (mut_stat) {
-		return -1;
-	}
-
-    ret = proteus_state.current_state;
-
-    osMutexRelease(proteus_state.state_mutex);
-
-    return ret;
-}
-
 void vStateMachineDirector(void *pv_params)
 {
-    proteus_state.current_state = LV_BOOT;
-
-    proteus_state.state_mutex = osMutexNew(&proteus_state.state_mutex_attr);
-	assert(proteus_state.state_mutex);
-
-    state_trans_queue = osMessageQueueNew(STATE_TRANS_QUEUE_SIZE, sizeof(state_t), NULL);
+    state_machine_t *sm = (state_machine_t *)pv_params;
+	assert(sm);
 
     state_t new_state;
 
     for (;;)
     {
-        if (osOK != osMessageQueueGet(state_trans_queue, &new_state, NULL, 50))
+        if (osOK != osMessageQueueGet(sm->state_trans_queue, &new_state, NULL, 50))
         {
             // TODO queue fault, low criticality
             continue;
         }
 
-        //if (!valid_trans_to_from[new_state][cerberus_state])
-        //{
-        //    // TODO queue fault, low criticality
-        //    continue;
-        //}
-//
-        //// transition state via LUT ?
-        //cerberus_state = new_state;
+        if (!valid_trans_to_from[new_state][sm->current_state])
+        {
+            // TODO queue fault, low criticality
+            continue;
+        }
+
+        printf("Transitioning state!\r\n");
+        /* transition state via LUT */
+        sm->current_state = new_state;
     }
 }


### PR DESCRIPTION
## Changes

Adding in per-motor state machines to track the spinning of each. This will allow both motors to function independently if needed.

## Notes

This implementation also makes the state machine implementation more modular, and we can easily switch to one state machine if need be.

## Test Cases

- Made sure code functions as it did before
- Builds
- Able to queue state transitions successfully